### PR TITLE
Fixes mozilla-mobile/focus-ios#630 - Adds a guard when starting a new…

### DIFF
--- a/Source/AutocompleteTextField.swift
+++ b/Source/AutocompleteTextField.swift
@@ -131,6 +131,11 @@ open class AutocompleteTextField: UITextField, UITextFieldDelegate {
         guard let completionRange = completionRange else { return }
 
         applyCompletion()
+
+        // Fixes: https://github.com/mozilla-mobile/focus-ios/issues/630
+        // Prevents the hard crash when you select all and start a new query
+        guard let count = text?.count, count > 1 else { return }
+
         text = (text as NSString?)?.replacingCharacters(in: completionRange, with: "")
     }
 


### PR DESCRIPTION
I found another crasher while selecting-all and dragging a handle to delete just one or two characters from the query. But that turned out to be quite a bit harder to fix in this implementation. It might be worth pulling in all the work @farhanpatel did into this